### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/docs/api/schemas/dataacquisition.md
+++ b/docs/api/schemas/dataacquisition.md
@@ -137,7 +137,7 @@ nav_order: 1
         },
         "horizontalResolution": {
             "title": "Horizontal resolution",
-            "brief": "horzontal pixels",
+            "brief": "horizontal pixels",
             "type": "number",
             "minimum": 0
         }

--- a/docs/api/schemas/equipment.md
+++ b/docs/api/schemas/equipment.md
@@ -137,7 +137,7 @@ nav_order: 1
         },
         "horizontalResolution": {
             "title": "Horizontal resolution",
-            "brief": "horzontal pixels",
+            "brief": "horizontal pixels",
             "type": "number",
             "minimum": 0
         }

--- a/docs/tutorials/matlab-api-tool.md
+++ b/docs/tutorials/matlab-api-tool.md
@@ -41,7 +41,7 @@ We can also filter the models by providing cell array with paired filters In thi
 output1_1 = load_model('model','session','filter',{'name','yeah'});
 ```
 
-Loaded models can be sorted by different criteria applying to their fields. In this example, sessions will be sorted in descending ording according to their name.
+Loaded models can be sorted by different criteria applying to their fields. In this example, sessions will be sorted in descending ordering according to their name.
 
 ```m
 output1_2 = load_model('model','session','sort',{'-name'});

--- a/docs/tutorials/python-api-tool.md
+++ b/docs/tutorials/python-api-tool.md
@@ -42,7 +42,7 @@ We can also filter the models by providing a dictionary where the keys are the f
 output1 = client.load_model('session', filters={'name': 'yeah'}).json()
 ```
 
-Loaded models can be sorted by different criteria applying to their fields. In this example, sessions will be sorted in descending ording according to their name.
+Loaded models can be sorted by different criteria applying to their fields. In this example, sessions will be sorted in descending ordering according to their name.
 
 ```
 output1 = client.load_model('session', sort=['-name']).json()
@@ -54,7 +54,7 @@ In some cases models contain relations with other models, and they can be also l
 output1 = client.load_model('session', include=['projects', 'dataacquisition', 'behaviors', 'manipulations']).json()
 ```
 
-The list of related data acquisition can be retrived from the returned dictionary.
+The list of related data acquisition can be retrieved from the returned dictionary.
 
 ```
 dataacquisition = output1["sessions"][0]["dataacquisition"]


### PR DESCRIPTION
Brainstem docs (https://support.brainstem.org/datamodel/schemas/coordinates/ in particular) came up during BEP032 discussions, which brought me here ;-)

More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.