### PR TITLE
Expand datamodel docs with new types and descriptions

### DIFF
--- a/docs/datamodel/modules/consumablestock.md
+++ b/docs/datamodel/modules/consumablestock.md
@@ -39,10 +39,15 @@ Consumable stocks refer to the various components and materials essential for co
 
 These are the available `type` options for Consumable stock:
 
+### Recording and Stimulation Equipment:
 - `OpticFiber`: A flexible light guide used primarily in optogenetic experiments to deliver light to specific brain regions. Optic fibers are essential in neuroscience for manipulating neural circuits using light.
 - `SiliconProbe`: A specialized tool for recording electrical signals from neurons. Silicon probes are vital for experiments focused on understanding brain function through electrophysiological recordings.
-- `VirusSolution`: A viral vector preparation used for introducing genes into cells. Virus solutions are important for studies involving gene expression, neural circuit tracing, and optogenetics.
 - `SingleWireElectrode`: A simple yet effective tool for measuring electrical activity at a single site. Single wire electrodes are commonly used in studies examining neural or muscular electrical activity.
+
+### Biological Solutions and Reagents:
+- `VirusSolution`: A viral vector preparation used for introducing genes into cells. Virus solutions are important for studies involving gene expression, neural circuit tracing, and optogenetics.
+- `ChemicalReagent`: General chemical compounds and solutions used in experimental procedures. This includes anesthetics, pharmacological agents, buffer solutions, and other chemical preparations essential for research protocols.
+- `ImmunoReagent`: Specialized biological reagents used in immunological procedures and assays. This includes antibodies, sera, immunological markers, and other immune-related biological materials.
 
 A detailed list of the accepted schemas for the `details` field, related to each `type`, can be found in the [Consumable stock schemas page]({{"/datamodel/schemas/consumablestock/"|absolute_url}}).
 

--- a/docs/datamodel/modules/procedure.md
+++ b/docs/datamodel/modules/procedure.md
@@ -50,10 +50,17 @@ These are the available *Type* options for Procedure:
 - `Silicon probe implant`: The insertion of a silicon-based probe equipped with multiple recording sites. These probes enable high-density recordings from many neurons simultaneously, facilitating detailed studies of neural circuits.
 - `Single wire electrode`: The implantation of a thin wire electrode into the brain for recording electrical activity or stimulating neurons. This targeted approach aids in understanding single-neuron contributions to brain function.
 - `Tetrode wire electrode`: The introduction of a four-wire electrode (tetrode) bundle into the brain. Tetrodes allow researchers to monitor and differentiate signals from multiple adjacent neurons, greatly enhancing the resolution of neural recordings.
+- `Generic implant`: A flexible implant category for various devices not covered by specific types. This includes sensors, optical devices, mechanical devices, and custom research tools with configurable anchoring and power options.
+- `GRIN lens implant`: The insertion of a gradient-index (GRIN) lens for deep-brain optical imaging. These miniature lenses enable high-resolution imaging of neural activity in deep brain structures that are otherwise inaccessible to conventional microscopy.
+- `Blood pressure sensor implant`: The surgical placement of pressure monitoring devices within the cardiovascular system. These sensors enable continuous, real-time monitoring of blood pressure changes during experimental procedures.
+- `Breathing sensor implant`: The implantation of respiratory monitoring devices to track breathing patterns and respiratory function. These sensors provide critical physiological data during experiments involving anesthesia or respiratory challenges.
 
 ### Injection and Infusion Procedures:
 - `Injection`: The delivery of solutions, often containing genetic or pharmacological agents, directly into targeted brain areas. This method is commonly performed using a small glass capillary and can be used to alter gene expression or modulate neural activity.
 - `Virus injection`: Similar to the above, but specifically involves injecting viral vectors to introduce or manipulate genetic material in targeted neuronal populations. This approach is key for studying gene function and developing gene therapies.
+
+### Fixation and Positioning Procedures:
+- `Head fixation`: The physical restraint of the head to ensure stable positioning during recording or experimental procedures. This technique enables precise control over head movement, facilitating high-quality data acquisition and consistent experimental conditions.
 
 ### Brain and Tissue Procedures:
 - `Brain lesion`: A deliberate injury or destruction of a specific brain region to investigate its role in behavior, cognition, and physiological processes. Lesion studies help map functions to particular brain areas.

--- a/docs/datamodel/modules/subjectlog.md
+++ b/docs/datamodel/modules/subjectlog.md
@@ -42,6 +42,9 @@ These are the available *Type* options for Subject logs:
 - `Water deprivation log`: Notes periods during which water is withheld from the subject. Similar to food deprivation, water deprivation can be used to study the effects of hydration status on various physiological and behavioral outcomes.
 - `Weighing log`: Records the subject's body weight over time. Regular weighing is critical for monitoring health, growth, and the effects of experimental treatments on body mass.
 - `Wellness log`: Documents observations related to the subject's general health and well-being, including behavior, physical appearance, signs of distress, or illness. This log is essential for ensuring the ethical treatment of research subjects and for interpreting the effects of experimental manipulations on overall health.
+- `Von Frey test`: Records mechanical sensitivity testing using Von Frey filaments. This standardized test measures withdrawal responses to graded mechanical stimuli and is commonly used to assess pain sensitivity, tactile thresholds, and the effects of analgesic treatments.
+- `Hargreaves test`: Documents thermal sensitivity testing using the Hargreaves method. This test measures withdrawal latencies to radiant heat stimuli applied to the paw and is a standard assessment for thermal pain sensitivity and hyperalgesia.
+- `Generic observation`: Captures flexible behavioral and welfare observations not covered by specific log types. This includes pain scoring, grooming behaviors, exploration patterns, and other custom observations important for research protocols.
 
 A detailed list of the type-specific fields can be found on the [subject logs types page]({{"datamodel/schemas/subjectlog/"|absolute_url}}).
 


### PR DESCRIPTION
Added new type options and detailed descriptions to the consumablestock, procedure, and subjectlog documentation. Consumablestock now includes ChemicalReagent and ImmunoReagent types. Procedure types expanded with generic implant, GRIN lens implant, blood pressure sensor implant, breathing sensor implant, and head fixation. Subjectlog types now include Von Frey test, Hargreaves test, and generic observation for broader experimental coverage.